### PR TITLE
Fix watchify

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -29,7 +29,7 @@ module.exports = {
         baseDir: [dest, src],
         directory: true
       },
-      open: true,
+      open: false,
       files: [
         dest + "/**",
         // Exclude Map files

--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -4,5 +4,5 @@ var buildMode = require('../config').buildMode;
 if(buildMode.dist) {
     gulp.task('default', ['dist']);
 } else {
-    gulp.task('default', ['unit', 'midway', 'watch']);
+    gulp.task('default', ['unit', 'midway:watch', 'watch']);
 }

--- a/gulp/tasks/midway.js
+++ b/gulp/tasks/midway.js
@@ -3,10 +3,18 @@ var
   karma = require('karma-as-promised'),
   testConf = require('../config').midway;
 
-gulp.task('midway', function () {
+gulp.task('midway', ['build'], function () {
   return karma.server
     .start({
              configFile: __dirname + '/' + testConf.karma,
              singleRun: true
            });
+});
+
+gulp.task('midway:watch', function () {
+  return karma.server
+  .start({
+    configFile: __dirname + '/' + testConf.karma,
+    singleRun: true
+  });
 });

--- a/gulp/tasks/midway.js
+++ b/gulp/tasks/midway.js
@@ -3,7 +3,7 @@ var
   karma = require('karma-as-promised'),
   testConf = require('../config').midway;
 
-gulp.task('midway', ['build'], function () {
+gulp.task('midway', function () {
   return karma.server
     .start({
              configFile: __dirname + '/' + testConf.karma,


### PR DESCRIPTION
The`midway` task cannot call `build` because `build` is already launched from `browserSync`.