### PR TITLE
pe-resourcetype-mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ simpler
 - Create a MockResourceType that can bulk-register default mocks for 
 the standard operations, making mock writing a lot simpler.
 
+- Get delete working on resource type crud.
+
 ## 0.0.7-alpha (2015-01-08)
 
 - Brownbag release to fix failure to do gulp --dist correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Refactor MdNav to make the declarative and imperative nav menu setup 
 simpler
 
+- Create a MockResourceType that can bulk-register default mocks for 
+the standard operations, making mock writing a lot simpler.
+
 ## 0.0.7-alpha (2015-01-08)
 
 - Brownbag release to fix failure to do gulp --dist correctly

--- a/TODO.md
+++ b/TODO.md
@@ -1,21 +1,12 @@
 = TODO
 
-- Basic Mocha unit tests
-
-    - Convert all directories to plugins
-  
-    - Services, controllers
-  
-    - Directives
-
-    * Later
-  
-        - Switch Karma and possibly Protractor from Jasmine to Mocha
-          
-        - Re-consider getting out of Karma and Protractor
-
+- Get Travis passing again
 
 - ng-grid
+
+- Switch Karma and possibly Protractor from Jasmine to Mocha
+  
+- Re-consider getting out of Karma and Protractor
 
 - Get rid of ng-min (use ng-annotate)
 

--- a/demos/full/mocks.js
+++ b/demos/full/mocks.js
@@ -87,10 +87,10 @@
       return {data: responseData};
     }
 
-    function InvoicesResponder(request) {
-      var id = request.url.split("/")[4];
-      return _(invoices).first({id: id}).value()[0];
-    }
+    //function InvoicesResponder(request) {
+    //  var id = request.url.split("/")[4];
+    //  return _(invoices).first({id: id}).value()[0];
+    //}
 
     function AuthLoginResponder(request) {
       if (request.json_body.username !== 'admin') {
@@ -128,8 +128,8 @@
 
     // Use the MockResourceType to create all  mocks for all the
     // standard endpoint actions.
-    var invoices = new MockResourceType('/api/resourcetypes', 'invoices', invoices);
-    MdMockRestProvider.addMocks(invoices.listMocks());
+    var invoicesMock = new MockResourceType('/api/resourcetypes', 'invoices', invoices);
+    MdMockRestProvider.addMocks(invoicesMock.listMocks());
   }
 
   angular.module('full')

--- a/demos/full/mocks.js
+++ b/demos/full/mocks.js
@@ -6,10 +6,10 @@
       exc = MdMockRestProvider.exceptions;
 
     /*   #####  Sample Data  ####  */
-    var invoices = [
-      {id: "invoice1", title: 'First invoice'},
-      {id: "invoice2", title: 'Second invoice'}
-    ];
+    var invoices = {
+      invoice1: {id: "invoice1", title: 'First invoice'},
+      invoice2: {id: "invoice2", title: 'Second invoice'}
+    };
 
     var features = {
       resource: {
@@ -119,6 +119,10 @@
           responseData: user,
           authenticate: true
         },
+        //{
+        //  pattern: '/api/resourcetypes/invoices/invoice1',
+        //  responseData: {id: 'invoice1', title: 'Invoice 1'}
+        //},
         {
           method: 'POST',
           pattern: /api\/auth\/login/,

--- a/demos/full/mocks.js
+++ b/demos/full/mocks.js
@@ -114,14 +114,6 @@
           pattern: /api\/root/,
           responder: resolvePath
         },
-        //{
-        //  pattern: /api\/resourcetypes\/invoices\/items$/,
-        //  responseData: invoices
-        //},
-        //{
-        //  pattern: /api\/resourcetypes\/invoices\//,
-        //  responder: InvoicesResponder
-        //},
         {
           pattern: /api\/auth\/me/,
           responseData: user,
@@ -134,9 +126,10 @@
         }
       ]);
 
-    // Let's give the new guy a whirl.
-    var mrt = new MockResourceType('/api/resourcetypes', 'invoices', invoices);
-    MdMockRestProvider.addMocks(mrt.listMocks());
+    // Use the MockResourceType to create all  mocks for all the
+    // standard endpoint actions.
+    var invoices = new MockResourceType('/api/resourcetypes', 'invoices', invoices);
+    MdMockRestProvider.addMocks(invoices.listMocks());
   }
 
   angular.module('full')

--- a/demos/full/mocks.js
+++ b/demos/full/mocks.js
@@ -1,7 +1,9 @@
 (function () {
   function ModuleConfig(MdMockRestProvider) {
 
-    var exc = MdMockRestProvider.exceptions;
+    var
+      MockResourceType = MdMockRestProvider.MockResourceType,
+      exc = MdMockRestProvider.exceptions;
 
     /*   #####  Sample Data  ####  */
     var invoices = [
@@ -112,14 +114,14 @@
           pattern: /api\/root/,
           responder: resolvePath
         },
-        {
-          pattern: /api\/resourcetypes\/invoices\/items$/,
-          responseData: invoices
-        },
-        {
-          pattern: /api\/resourcetypes\/invoices\//,
-          responder: InvoicesResponder
-        },
+        //{
+        //  pattern: /api\/resourcetypes\/invoices\/items$/,
+        //  responseData: invoices
+        //},
+        //{
+        //  pattern: /api\/resourcetypes\/invoices\//,
+        //  responder: InvoicesResponder
+        //},
         {
           pattern: /api\/auth\/me/,
           responseData: user,
@@ -132,6 +134,9 @@
         }
       ]);
 
+    // Let's give the new guy a whirl.
+    var mrt = new MockResourceType('/api/resourcetypes', 'invoices', invoices);
+    MdMockRestProvider.addMocks(mrt.listMocks());
   }
 
   angular.module('full')

--- a/demos/full/siteconfig.json
+++ b/demos/full/siteconfig.json
@@ -58,7 +58,7 @@
     "demo": {
       "id": "demo",
       "label": "Demo",
-      "priority": 2,
+      "priority": 4,
       "items": [
         {
           "id": "site.dispatch",
@@ -105,7 +105,7 @@
     "security": {
       "id": "security",
       "label": "Security and Errors",
-      "priority": 4,
+      "priority": 2,
       "items": [
         {
           "id": "security.none",

--- a/src/mockapi/exceptions.js
+++ b/src/mockapi/exceptions.js
@@ -1,0 +1,29 @@
+/*
+
+ Standard HTTP exceptions that can be thrown in mock implementations
+ and have the correct status code returned.
+
+ */
+
+// Custom exceptions that can be used by mocks, stored later on
+// the service
+function HTTPNotFound(message) {
+  this.name = 'HTTPNotFound';
+  this.statusCode = 404;
+  this.message = message || 'Not Found';
+}
+function HTTPUnauthorized(message) {
+  this.name = 'HTTPUnauthorized';
+  this.statusCode = 401;
+  this.message = message || 'Login Required';
+}
+function HTTPNoContent() {
+  this.name = 'HTTPNoContent';
+  this.statusCode = 204;
+}
+
+module.exports = {
+  HTTPNotFound: HTTPNotFound,
+  HTTPUnauthorized: HTTPUnauthorized,
+  HTTPNoContent: HTTPNoContent
+};

--- a/src/mockapi/mock_resource_type.js
+++ b/src/mockapi/mock_resource_type.js
@@ -1,0 +1,52 @@
+/*
+
+ Base class to quickly build up a mock REST API for a resource type:
+
+ - Collections and documents
+ - Standard operations with default (but overridable) implementations
+ - Extensible, custom operations
+
+ */
+
+'use strict';
+
+var _ = require('lodash');
+
+function MockResourceType(prefix, id, items) {
+  // A prototype/class that can generate the mocks for all the
+  // actions on a type, with default methods that can be overriden as
+  // well as custom actions with methods to extend the REST API.
+
+  this.prefix = prefix;             // e.g. /api/resourcetypes
+  this.id = id;                     // e.g. invoices (plural)
+  this.items = items ? items : {};
+
+  this.collectionREAD = function () {
+    // Only provide the properties of this collection, not items
+    var clone = _(this).clone();
+    delete clone.items;
+    return clone;
+  };
+
+  this.collectionLIST = function () {
+    // Return the items in this collection as a mapping
+    // TODO implement pagination, filtering, etc.
+    return this.items;
+  };
+
+  this.collectionUPDATE = function () {
+    //
+
+  };
+
+  this.collectionREPLACE = function () {
+    //
+
+  };
+
+
+}
+
+module.exports = {
+  MockResourceType: MockResourceType
+};

--- a/src/mockapi/mock_resource_type.js
+++ b/src/mockapi/mock_resource_type.js
@@ -15,6 +15,17 @@ var
   path = require('path'),
   exceptions = require('./exceptions');
 
+function makePatternRegExp(prefix, id, suffix) {
+  if (prefix[0] == '/') {
+    // Remove this
+    prefix = prefix.substring(1);
+  }
+  var p = path.join(prefix, id, suffix);
+  p = p.replace(/\//g, '\\/');
+  return new RegExp(p);
+}
+
+
 function MockResourceType(prefix, id, items) {
   // A prototype/class that can generate the mocks for all the
   // actions on a type, with default methods that can be overriden as
@@ -29,7 +40,7 @@ function MockResourceType(prefix, id, items) {
     // TODO implement pagination, filtering, etc.
 
     return this.items;
-  }
+  };
 
   this.collectionREAD = function (request) {
     // Only provide the properties of this collection, not items
@@ -49,34 +60,28 @@ function MockResourceType(prefix, id, items) {
   };
 
   this.collectionREPLACE = function () {
-    // HANDLE a PUT
+    // Handle a PUT
 
+  };
+
+  this.documentREAD = function (request) {
+    // Handle a GET to a leaf
+    return 9;
   };
 
   this.listMocks = function () {
     // Get a list of MdMockRest-compatible registrations
 
-    var _this = this;
-
-    function makeRegEx(suffix) {
-      var prefix = _this.prefix;
-      if (prefix[0] == '/') {
-        // Remove this
-        prefix = prefix.substring(1);
-      }
-      var p = path.join(prefix, _this.id, suffix);
-      p = p.replace(/\//g, '\\/');
-      return new RegExp(p);
-    }
-
     var
       mocks = [],
-      basePattern = path.join(this.prefix, this.id);
+      basePattern = path.join(this.prefix, this.id),
+      prefix = this.prefix,
+      id = this.id;
 
     // Collection items
     mocks.push({
                  mockInstance: this,
-                 pattern: makeRegEx('/items$'),
+                 pattern: makePatternRegExp(prefix, id, '/items$'),
                  responder: this.collectionLIST
                });
 
@@ -97,5 +102,6 @@ function MockResourceType(prefix, id, items) {
 
 
 module.exports = {
+  makePatternRegExp: makePatternRegExp,
   MockResourceType: MockResourceType
 };

--- a/src/mockapi/mock_resource_type.js
+++ b/src/mockapi/mock_resource_type.js
@@ -73,11 +73,26 @@ function MockResourceType(prefix, id, items) {
   this.collectionUPDATE = function (request) {
     // Handle a PATCH
 
+    // For each key/value in the request.json_body, update
+    _(request.json_body)
+      .map(function (value, key) {
+             this[key] = value;
+           },
+           this);
+
+    return null;
   };
 
-  this.collectionREPLACE = function () {
+  this.collectionREPLACE = function (request) {
     // Handle a PUT
 
+    // For each key/value in the request.json_body, update
+    _(request.json_body)
+      .map(function (value, key) {
+             this[key] = value;
+           },
+           this);
+    return null;
   };
 
   this.documentREAD = function (request) {
@@ -91,7 +106,7 @@ function MockResourceType(prefix, id, items) {
 
     var pathname = request.pathname;
     var basePos = path.join(this.prefix, this.id).split('/').length;
-    var resourceId = pathname.trim().split('/')[basePos+1];
+    var resourceId = pathname.trim().split('/')[basePos + 1];
 
     delete this.items[resourceId];
 

--- a/src/mockapi/mock_resource_type.js
+++ b/src/mockapi/mock_resource_type.js
@@ -12,6 +12,7 @@
 
 var
   _ = require('lodash'),
+  path = require('path'),
   exceptions = require('./exceptions');
 
 function MockResourceType(prefix, id, items) {
@@ -31,27 +32,49 @@ function MockResourceType(prefix, id, items) {
 
     var clone = _(this).clone();
     delete clone.items;
+
     return clone;
   };
 
-  this.collectionLIST = function () {
-    // Return the items in this collection as a mapping
-    // TODO implement pagination, filtering, etc.
-    return this.items;
-  };
-
-  this.collectionUPDATE = function () {
-    //
+  this.collectionUPDATE = function (request) {
+    // Handle a PATCH
 
   };
 
   this.collectionREPLACE = function () {
-    //
+    // HANDLE a PUT
 
   };
 
+  this.listMocks = function () {
+    // Get a list of MdMockRest-compatible registrations
+
+    var
+      mocks = [],
+      basePattern = path.join(this.prefix, this.id);
+
+    // Collection items
+    mocks.push({
+                 mockInstance: this,
+                 pattern: basePattern + '/items',
+                 responder: this.collectionLIST
+               });
+
+    // Finally, push collectionGET to match last
+    mocks.push({pattern: basePattern, responder: this.collectionREAD});
+
+    return mocks;
+  };
 
 }
+
+MockResourceType.prototype.collectionLIST = function (request) {
+  // Return the items in this collection as a mapping
+  // TODO implement pagination, filtering, etc.
+
+  return this.items;
+};
+
 
 module.exports = {
   MockResourceType: MockResourceType

--- a/src/mockapi/mock_resource_type.js
+++ b/src/mockapi/mock_resource_type.js
@@ -86,6 +86,19 @@ function MockResourceType(prefix, id, items) {
     return this.getDocument(request.pathname);
   };
 
+  this.documentDELETE = function (request) {
+    // Handle a DELETE to a leaf
+
+    var pathname = request.pathname;
+    var basePos = path.join(this.prefix, this.id).split('/').length;
+    var resourceId = pathname.trim().split('/')[basePos+1];
+
+    delete this.items[resourceId];
+
+    return {status: 'Ok'};
+  };
+
+
   this.listMocks = function () {
     // Get a list of MdMockRest-compatible registrations
 
@@ -101,6 +114,12 @@ function MockResourceType(prefix, id, items) {
                  responder: this.collectionLIST
                });
 
+    mocks.push({
+                 mockInstance: this,
+                 method: 'DELETE',
+                 pattern: makePatternRegExp(prefix, id + '/*'),
+                 responder: this.documentDELETE
+               });
     mocks.push({
                  mockInstance: this,
                  method: 'GET',

--- a/src/mockapi/mock_resource_type.js
+++ b/src/mockapi/mock_resource_type.js
@@ -10,7 +10,9 @@
 
 'use strict';
 
-var _ = require('lodash');
+var
+  _ = require('lodash'),
+  exceptions = require('./exceptions');
 
 function MockResourceType(prefix, id, items) {
   // A prototype/class that can generate the mocks for all the
@@ -21,8 +23,12 @@ function MockResourceType(prefix, id, items) {
   this.id = id;                     // e.g. invoices (plural)
   this.items = items ? items : {};
 
-  this.collectionREAD = function () {
+  this.collectionREAD = function (request) {
     // Only provide the properties of this collection, not items
+
+    // Let's do some assertions and throw errors to make writing
+    // mocks more reliable and thus productive
+
     var clone = _(this).clone();
     delete clone.items;
     return clone;

--- a/src/mockapi/mock_resource_type.js
+++ b/src/mockapi/mock_resource_type.js
@@ -24,6 +24,13 @@ function MockResourceType(prefix, id, items) {
   this.id = id;                     // e.g. invoices (plural)
   this.items = items ? items : {};
 
+  this.collectionLIST = function (request) {
+    // Return the items in this collection as a mapping
+    // TODO implement pagination, filtering, etc.
+
+    return this.items;
+  }
+
   this.collectionREAD = function (request) {
     // Only provide the properties of this collection, not items
 
@@ -49,6 +56,19 @@ function MockResourceType(prefix, id, items) {
   this.listMocks = function () {
     // Get a list of MdMockRest-compatible registrations
 
+    var _this = this;
+
+    function makeRegEx(suffix) {
+      var prefix = _this.prefix;
+      if (prefix[0] == '/') {
+        // Remove this
+        prefix = prefix.substring(1);
+      }
+      var p = path.join(prefix, _this.id, suffix);
+      p = p.replace(/\//g, '\\/');
+      return new RegExp(p);
+    }
+
     var
       mocks = [],
       basePattern = path.join(this.prefix, this.id);
@@ -56,7 +76,7 @@ function MockResourceType(prefix, id, items) {
     // Collection items
     mocks.push({
                  mockInstance: this,
-                 pattern: basePattern + '/items',
+                 pattern: makeRegEx('/items$'),
                  responder: this.collectionLIST
                });
 
@@ -68,12 +88,12 @@ function MockResourceType(prefix, id, items) {
 
 }
 
-MockResourceType.prototype.collectionLIST = function (request) {
-  // Return the items in this collection as a mapping
-  // TODO implement pagination, filtering, etc.
-
-  return this.items;
-};
+//MockResourceType.prototype.collectionLIST = function (request) {
+//  // Return the items in this collection as a mapping
+//  // TODO implement pagination, filtering, etc.
+//
+//  return this.items;
+//};
 
 
 module.exports = {

--- a/src/mockapi/providers.js
+++ b/src/mockapi/providers.js
@@ -2,7 +2,8 @@
 
 var
   _ = require('lodash'),
- url = require('url'),
+  url = require('url'),
+  MockResourceType = require('./mock_resource_type').MockResourceType,
   exceptions = require('./exceptions');
 
 
@@ -44,7 +45,12 @@ function Dispatcher(mock, method, thisUrl, data, headers) {
   // it with the appropriate status code.
   try {
     resultCode = 200;
-    resultData = responder(request);
+    if (mock.mockInstance) {
+      // Supply a "this" to the mock function
+      resultData = responder.call(mock.mockInstance, request);
+    } else {
+      resultData = responder(request);
+    }
   } catch (e) {
     if (e instanceof exceptions.HTTPNotFound) {
       resultCode = e.statusCode;
@@ -64,6 +70,7 @@ function Dispatcher(mock, method, thisUrl, data, headers) {
 function MockRest() {
   var _this = this;
   this.mocks = [];
+  this.MockResourceType = MockResourceType;
   this.exceptions = exceptions;
 
   this.$get = function () {

--- a/src/mockapi/providers.js
+++ b/src/mockapi/providers.js
@@ -1,7 +1,9 @@
 'use strict';
 
-var _ = require('lodash');
-var url = require('url');
+var
+  _ = require('lodash'),
+ url = require('url'),
+  exceptions = require('./exceptions');
 
 // Custom exceptions that can be used by mocks, stored later on
 // the service
@@ -24,7 +26,7 @@ function HTTPNoContent() {
 function Dispatcher(mock, method, thisUrl, data, headers) {
   // Called by $httpBackend whenever this mock's pattern is matched.
 
-  var responder, responseData, response, request;
+  var responder, responseData, request;
 
   // If the mock says to authenticate and we don't have
   // an Authorization header, return 401.
@@ -79,11 +81,7 @@ function Dispatcher(mock, method, thisUrl, data, headers) {
 function MockRest() {
   var _this = this;
   this.mocks = [];
-  this.exceptions = {
-    HTTPNotFound: HTTPNotFound,
-    HTTPUnauthorized: HTTPUnauthorized,
-    HTTPNoContent: HTTPNoContent
-  };
+  this.exceptions = exceptions;
 
   this.$get = function () {
     var mocks = this.mocks;

--- a/src/mockapi/providers.js
+++ b/src/mockapi/providers.js
@@ -5,23 +5,6 @@ var
  url = require('url'),
   exceptions = require('./exceptions');
 
-// Custom exceptions that can be used by mocks, stored later on
-// the service
-function HTTPNotFound(message) {
-  this.name = 'HTTPNotFound';
-  this.statusCode = 404;
-  this.message = message || 'Not Found';
-}
-function HTTPUnauthorized(message) {
-  this.name = 'HTTPUnauthorized';
-  this.statusCode = 401;
-  this.message = message || 'Login Required';
-}
-function HTTPNoContent() {
-  this.name = 'HTTPNoContent';
-  this.statusCode = 204;
-}
-
 
 function Dispatcher(mock, method, thisUrl, data, headers) {
   // Called by $httpBackend whenever this mock's pattern is matched.
@@ -130,8 +113,5 @@ function ModuleRun($httpBackend, MdMockRest) {
 module.exports = {
   MockRest: MockRest,
   Run: ModuleRun,
-  Dispatcher: Dispatcher,
-  HTTPNotFound: HTTPNotFound,
-  HTTPUnauthorized: HTTPUnauthorized,
-  HTTPNoContent: HTTPNoContent
+  Dispatcher: Dispatcher
 };

--- a/src/mockapi/providers.js
+++ b/src/mockapi/providers.js
@@ -46,13 +46,13 @@ function Dispatcher(mock, method, thisUrl, data, headers) {
     resultCode = 200;
     resultData = responder(request);
   } catch (e) {
-    if (e instanceof HTTPNotFound) {
+    if (e instanceof exceptions.HTTPNotFound) {
       resultCode = e.statusCode;
       resultData = {message: e.message};
-    } else if (e instanceof HTTPUnauthorized) {
+    } else if (e instanceof exceptions.HTTPUnauthorized) {
       resultCode = e.statusCode;
       resultData = {message: e.message};
-    } else if (e instanceof HTTPNoContent) {
+    } else if (e instanceof exceptions.HTTPNoContent) {
       resultCode = e.statusCode;
       resultData = null;
     }

--- a/src/mockapi/test/unit/exceptions.js
+++ b/src/mockapi/test/unit/exceptions.js
@@ -6,7 +6,7 @@ var
   spy = helper.spy,
   stub = helper.stub;
 
-describe.only('mockapi Exceptions', function () {
+describe('mockapi Exceptions', function () {
 
   var
     exc = require('../../exceptions');

--- a/src/mockapi/test/unit/exceptions.js
+++ b/src/mockapi/test/unit/exceptions.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var
+  helper = require('../../../common/test-helper'),
+  expect = helper.expect,
+  spy = helper.spy,
+  stub = helper.stub;
+
+describe.only('mockapi Exceptions', function () {
+
+  var
+    exc = require('../../exceptions');
+
+  describe('Exception Basics', function () {
+
+    it('should have Not Found', function () {
+      expect(exc.HTTPNotFound).to.exist();
+      expect(exc.HTTPNotFound).to.be.a('function');
+      var e = new exc.HTTPNotFound();
+      expect(e.name).to.equal('HTTPNotFound');
+      expect(e.statusCode).to.equal(404);
+      expect(e.message).to.equal('Not Found');
+    });
+
+    it('should have Not Found with a message', function () {
+      var e = new exc.HTTPNotFound('x');
+      expect(e.message).to.equal('x');
+    });
+
+    it('should have Unauthorized', function () {
+      expect(exc.HTTPUnauthorized).to.exist();
+      expect(exc.HTTPUnauthorized).to.be.a('function');
+      var e = new exc.HTTPUnauthorized();
+      expect(e.name).to.equal('HTTPUnauthorized');
+      expect(e.statusCode).to.equal(401);
+      expect(e.message).to.equal('Login Required');
+    });
+
+    it('should have Unauthorized with a message', function () {
+      var e = new exc.HTTPUnauthorized('x');
+      expect(e.message).to.equal('x');
+    });
+
+    it('should have No Content', function () {
+      expect(exc.HTTPNoContent).to.exist();
+      expect(exc.HTTPNoContent).to.be.a('function');
+      var e = new exc.HTTPNoContent();
+      expect(e.name).to.equal('HTTPNoContent');
+      expect(e.statusCode).to.equal(204);
+      expect(e.message).to.be.undefined();
+    });
+
+  });
+
+});

--- a/src/mockapi/test/unit/mock_resource_type.js
+++ b/src/mockapi/test/unit/mock_resource_type.js
@@ -72,7 +72,7 @@ describe('mockapi MockResourceType', function () {
       expect(mrt.description).to.equal('After Description');
     });
 
-    it('should perform an REPLACE action', function () {
+    it('should perform a REPLACE action', function () {
       mrt.title = 'Before Title';
       mrt.description = 'Before Description';
       var json_body = {
@@ -101,6 +101,43 @@ describe('mockapi MockResourceType', function () {
       expect(result.items).to.be.undefined();
     });
 
+    it('should perform a DELETE action', function () {
+      var request = {pathname: '/api/invoices/item1'};
+      var result = mrt.documentDELETE(request);
+      expect(result).to.be.null();
+      expect(mrt.items).to.be.empty();
+    });
+
+    it('should perform an UPDATE action', function () {
+      var json_body = {
+        title: 'After Title',
+        description: 'After Description'
+      };
+      var request = {
+        pathname: '/api/invoices/item1',
+        json_body: json_body
+      };
+      var result = mrt.documentUPDATE(request);
+      expect(result).to.be.null();
+      expect(mrt.items.item1.title).to.equal('After Title');
+      expect(mrt.items.item1.description).to.equal('After Description');
+    });
+
+    it('should perform a REPLACE action', function () {
+      var json_body = {
+        title: 'After Title',
+        description: 'After Description'
+      };
+      var request = {
+        pathname: '/api/invoices/item1',
+        json_body: json_body
+      };
+      var result = mrt.documentREPLACE(request);
+      expect(result).to.be.null();
+      expect(mrt.items.item1.title).to.equal('After Title');
+      expect(mrt.items.item1.description).to.equal('After Description');
+    });
+
   });
 
   describe('List Mocks for MockRest registrations', function () {
@@ -110,6 +147,35 @@ describe('mockapi MockResourceType', function () {
       var regex = '/\\/api\\/invoices\\/items/';
       expect(result[0].pattern.toString()).to.equal(regex);
       expect(result[0].responder).to.be.a('function');
+    });
+
+  });
+
+  describe('Extract the resource ID from various patterns', function () {
+
+    beforeEach(function () {
+      mrt = new MockResourceType(prefix, 'invoices');
+    });
+
+    it('should find the ID in a basic pathname', function () {
+      var pathname = '/api/invoices/1';
+      expect(mrt.getId(pathname)).to.equal('1');
+    });
+
+    it('should find ID in pathname with trailing slash', function () {
+      var pathname = '/api/invoices/1/';
+      expect(mrt.getId(pathname)).to.equal('1');
+    });
+
+    it('should find ID in deeply nested pathname', function () {
+      var pathname = '/api/and/more/resourcetypes/invoices/1/';
+      mrt = new MockResourceType('/api/and/more/resourcetypes', 'invoices');
+      expect(mrt.getId(pathname)).to.equal('1');
+    });
+
+    it('should find ID in pathname with extra action', function () {
+      var pathname = '/api/invoices/1/someAction';
+      expect(mrt.getId(pathname)).to.equal('1');
     });
 
   });

--- a/src/mockapi/test/unit/mock_resource_type.js
+++ b/src/mockapi/test/unit/mock_resource_type.js
@@ -10,6 +10,7 @@ describe('mockapi MockResourceType', function () {
 
   var
     MockResourceType = require('../../mock_resource_type').MockResourceType,
+    exceptions = require('../../exceptions'),
     mrt;
 
   describe('Basics', function () {
@@ -45,10 +46,15 @@ describe('mockapi MockResourceType', function () {
       mrt = new MockResourceType('/api/resourcetypes', 'invoices', items);
     });
 
-    it('should perform READ action', function () {
+    it('should perform a READ action', function () {
       var result = mrt.collectionREAD();
       expect(result.id).to.equal('invoices');
       expect(result.items).to.be.undefined();
+    });
+
+    it('should perform a LIST action', function () {
+      var result = mrt.collectionLIST();
+      expect(result.item1.id).to.equal('item1');
     });
 
   });

--- a/src/mockapi/test/unit/mock_resource_type.js
+++ b/src/mockapi/test/unit/mock_resource_type.js
@@ -65,7 +65,8 @@ describe('mockapi MockResourceType', function () {
 
     it('should provide list of collection/resource mocks', function () {
       var result = mrt.listMocks();
-      expect(result[0].pattern).to.equal(prefix + '/invoices/items');
+      var regex = '/api\\/resourcetypes\\/invoices\\/items$/';
+      expect(result[0].pattern.toString()).to.equal(regex);
       expect(result[0].responder).to.be.a('function');
     });
 

--- a/src/mockapi/test/unit/mock_resource_type.js
+++ b/src/mockapi/test/unit/mock_resource_type.js
@@ -6,7 +6,7 @@ var
   spy = helper.spy,
   stub = helper.stub;
 
-describe('MockResourceType', function () {
+describe('mockapi MockResourceType', function () {
 
   var
     MockResourceType = require('../../mock_resource_type').MockResourceType,

--- a/src/mockapi/test/unit/mock_resource_type.js
+++ b/src/mockapi/test/unit/mock_resource_type.js
@@ -61,6 +61,20 @@ describe('mockapi MockResourceType', function () {
 
   });
 
+  describe('Default Document Actions', function () {
+
+    beforeEach(function () {
+      var items = {'item1': {id: 'item1', resource_type: 'invoice'}};
+      mrt = new MockResourceType(prefix, 'invoices', items);
+    });
+
+    it('should perform a READ action', function () {
+      var result = mrt.collectionREAD();
+      expect(result.id).to.equal('invoices');
+      expect(result.items).to.be.undefined();
+    });
+  });
+
   describe('List Mocks for MockRest registrations', function () {
 
     it('should provide list of collection/resource mocks', function () {
@@ -70,6 +84,14 @@ describe('mockapi MockResourceType', function () {
       expect(result[0].responder).to.be.a('function');
     });
 
+  });
+
+  describe('Make Pattern Regexes', function () {
+    var makePatternRegExp = require('../../mock_resource_type').makePatternRegExp;
+    it('should make a compatible regex', function () {
+      var result = makePatternRegExp('somePrefix', 'someId', 'someSuffix');
+      expect(result.toString()).to.equal('/somePrefix\\/someId\\/someSuffix/');
+    });
   });
 
 });

--- a/src/mockapi/test/unit/mock_resource_type.js
+++ b/src/mockapi/test/unit/mock_resource_type.js
@@ -11,7 +11,8 @@ describe('mockapi MockResourceType', function () {
   var
     MockResourceType = require('../../mock_resource_type').MockResourceType,
     exceptions = require('../../exceptions'),
-    mrt;
+    mrt,
+    prefix = '/api/resourcetypes';
 
   describe('Basics', function () {
 
@@ -41,9 +42,10 @@ describe('mockapi MockResourceType', function () {
   });
 
   describe('Default Collection Actions', function () {
+
     beforeEach(function () {
       var items = {'item1': {id: 'item1', resource_type: 'invoice'}};
-      mrt = new MockResourceType('/api/resourcetypes', 'invoices', items);
+      mrt = new MockResourceType(prefix, 'invoices', items);
     });
 
     it('should perform a READ action', function () {
@@ -55,6 +57,16 @@ describe('mockapi MockResourceType', function () {
     it('should perform a LIST action', function () {
       var result = mrt.collectionLIST();
       expect(result.item1.id).to.equal('item1');
+    });
+
+  });
+
+  describe('List Mocks for MockRest registrations', function () {
+
+    it('should provide list of collection/resource mocks', function () {
+      var result = mrt.listMocks();
+      expect(result[0].pattern).to.equal(prefix + '/invoices/items');
+      expect(result[0].responder).to.be.a('function');
     });
 
   });

--- a/src/mockapi/test/unit/mock_resource_type.js
+++ b/src/mockapi/test/unit/mock_resource_type.js
@@ -12,18 +12,18 @@ describe('mockapi MockResourceType', function () {
     MockResourceType = require('../../mock_resource_type').MockResourceType,
     exceptions = require('../../exceptions'),
     mrt,
-    prefix = '/api/resourcetypes';
+    prefix = '/api';
 
   describe('Basics', function () {
 
     beforeEach(function () {
       var items = {'item1': {id: 'item1', resource_type: 'invoice'}};
-      mrt = new MockResourceType('/api/resourcetypes', 'invoices', items);
+      mrt = new MockResourceType('/api', 'invoices', items);
     });
 
     it('should provide basic instance', function () {
       expect(mrt).to.exist();
-      expect(mrt.prefix).to.equal('/api/resourcetypes');
+      expect(mrt.prefix).to.equal('/api');
       expect(mrt.id).to.equal('invoices');
       expect(mrt.items).to.be.a('object');
       expect(mrt.items).to.not.be.empty();
@@ -31,9 +31,9 @@ describe('mockapi MockResourceType', function () {
     });
 
     it('should provide basic instance with no items', function () {
-      mrt = new MockResourceType('/api/resourcetypes', 'invoices');
+      mrt = new MockResourceType('/api', 'invoices');
       expect(mrt).to.exist();
-      expect(mrt.prefix).to.equal('/api/resourcetypes');
+      expect(mrt.prefix).to.equal('/api');
       expect(mrt.id).to.equal('invoices');
       expect(mrt.items).to.be.a('object');
       expect(mrt.items).to.be.empty();
@@ -56,7 +56,7 @@ describe('mockapi MockResourceType', function () {
 
     it('should perform a LIST action', function () {
       var result = mrt.collectionLIST();
-      expect(result.item1.id).to.equal('item1');
+      expect(result[0].id).to.equal('item1');
     });
 
   });
@@ -69,17 +69,19 @@ describe('mockapi MockResourceType', function () {
     });
 
     it('should perform a READ action', function () {
-      var result = mrt.collectionREAD();
-      expect(result.id).to.equal('invoices');
+      var request = {pathname: '/api/invoices/item1'};
+      var result = mrt.documentREAD(request);
+      expect(result.id).to.equal('item1');
       expect(result.items).to.be.undefined();
     });
+
   });
 
   describe('List Mocks for MockRest registrations', function () {
 
     it('should provide list of collection/resource mocks', function () {
       var result = mrt.listMocks();
-      var regex = '/api\\/resourcetypes\\/invoices\\/items$/';
+      var regex = '/\\/api\\/invoices\\/items/';
       expect(result[0].pattern.toString()).to.equal(regex);
       expect(result[0].responder).to.be.a('function');
     });
@@ -87,11 +89,42 @@ describe('mockapi MockResourceType', function () {
   });
 
   describe('Make Pattern Regexes', function () {
+
     var makePatternRegExp = require('../../mock_resource_type').makePatternRegExp;
+
     it('should make a compatible regex', function () {
       var result = makePatternRegExp('somePrefix', 'someId', 'someSuffix');
       expect(result.toString()).to.equal('/somePrefix\\/someId\\/someSuffix/');
     });
+
+    it('should handle missing optional suffix', function () {
+      var result = makePatternRegExp('somePrefix', 'someId');
+      expect(result.toString()).to.equal('/somePrefix\\/someId/');
+    });
+
   });
+
+  describe('Get Documents from Collections', function () {
+
+    beforeEach(function () {
+      var items = {'item1': {id: 'item1', resource_type: 'invoice'}};
+      mrt = new MockResourceType(prefix, 'invoices', items);
+    });
+
+    it('should find a document', function () {
+      var pathname = '/api/invoices/item1';
+      var result = mrt.getDocument(pathname);
+      expect(result.id).to.equal('item1');
+    });
+
+    it('should throw an HTTPNotFound', function () {
+      var pathname = '/api/invoices/xxx';
+      expect(function () {
+        mrt.getDocument(pathname)
+      }).to.throw('No document at: /api/invoices/xxx');
+    });
+
+  });
+
 
 });

--- a/src/mockapi/test/unit/mock_resource_type.js
+++ b/src/mockapi/test/unit/mock_resource_type.js
@@ -59,6 +59,32 @@ describe('mockapi MockResourceType', function () {
       expect(result[0].id).to.equal('item1');
     });
 
+    it('should perform an UPDATE action', function () {
+      mrt.title = 'Before Title';
+      mrt.description = 'Before Description';
+      var json_body = {
+        title: 'After Title',
+        description: 'After Description'
+      };
+      var result = mrt.collectionUPDATE({json_body: json_body});
+      expect(result).to.be.null();
+      expect(mrt.title).to.equal('After Title');
+      expect(mrt.description).to.equal('After Description');
+    });
+
+    it('should perform an REPLACE action', function () {
+      mrt.title = 'Before Title';
+      mrt.description = 'Before Description';
+      var json_body = {
+        title: 'After Title',
+        description: 'After Description'
+      };
+      var result = mrt.collectionREPLACE({json_body: json_body});
+      expect(result).to.be.null();
+      expect(mrt.title).to.equal('After Title');
+      expect(mrt.description).to.equal('After Description');
+    });
+
   });
 
   describe('Default Document Actions', function () {

--- a/src/mockapi/test/unit/mock_resource_type.js
+++ b/src/mockapi/test/unit/mock_resource_type.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var
+  helper = require('../../../common/test-helper'),
+  expect = helper.expect,
+  spy = helper.spy,
+  stub = helper.stub;
+
+describe('MockResourceType', function () {
+
+  var
+    MockResourceType = require('../../mock_resource_type').MockResourceType,
+    mrt;
+
+  describe('Basics', function () {
+
+    beforeEach(function () {
+      var items = {'item1': {id: 'item1', resource_type: 'invoice'}};
+      mrt = new MockResourceType('/api/resourcetypes', 'invoices', items);
+    });
+
+    it('should provide basic instance', function () {
+      expect(mrt).to.exist();
+      expect(mrt.prefix).to.equal('/api/resourcetypes');
+      expect(mrt.id).to.equal('invoices');
+      expect(mrt.items).to.be.a('object');
+      expect(mrt.items).to.not.be.empty();
+      expect(mrt.items['item1'].id).to.equal('item1');
+    });
+
+    it('should provide basic instance with no items', function () {
+      mrt = new MockResourceType('/api/resourcetypes', 'invoices');
+      expect(mrt).to.exist();
+      expect(mrt.prefix).to.equal('/api/resourcetypes');
+      expect(mrt.id).to.equal('invoices');
+      expect(mrt.items).to.be.a('object');
+      expect(mrt.items).to.be.empty();
+    });
+
+  });
+
+  describe('Default Collection Actions', function () {
+    beforeEach(function () {
+      var items = {'item1': {id: 'item1', resource_type: 'invoice'}};
+      mrt = new MockResourceType('/api/resourcetypes', 'invoices', items);
+    });
+
+    it('should perform READ action', function () {
+      var result = mrt.collectionREAD();
+      expect(result.id).to.equal('invoices');
+      expect(result.items).to.be.undefined();
+    });
+
+  });
+
+});

--- a/src/mockapi/test/unit/providers.js
+++ b/src/mockapi/test/unit/providers.js
@@ -11,7 +11,8 @@ describe('mockapi MockRest', function () {
   var
     providers = require('../../providers'),
     MockRest = providers.MockRest,
-    Dispatcher = providers.Dispatcher;
+    Dispatcher = providers.Dispatcher,
+    exceptions = require('../../exceptions');
 
   describe('Provider Basics', function () {
 
@@ -97,9 +98,8 @@ describe('mockapi MockRest', function () {
     });
 
     it('should handle a raised HTTPNotFound', function () {
-      var HTTPNotFound = providers.HTTPNotFound;
       var responder = function () {
-        throw new HTTPNotFound('some message');
+        throw new exceptions.HTTPNotFound('some message');
       };
       mock = {responder: responder};
       result = Dispatcher(mock, method, thisUrl, data, headers);
@@ -110,9 +110,8 @@ describe('mockapi MockRest', function () {
     });
 
     it('should handle a raised unauthorized', function () {
-      var HTTPUnauthorized = providers.HTTPUnauthorized;
       var responder = function () {
-        throw new HTTPUnauthorized('some message');
+        throw new exceptions.HTTPUnauthorized('some message');
       };
       mock = {responder: responder};
       result = Dispatcher(mock, method, thisUrl, data, headers);
@@ -123,9 +122,8 @@ describe('mockapi MockRest', function () {
     });
 
     it('should handle a raised no content', function () {
-      var HTTPNoContent = providers.HTTPNoContent;
       var responder = function () {
-        throw new HTTPNoContent();
+        throw new exceptions.HTTPNoContent();
       };
       mock = {responder: responder};
       result = Dispatcher(mock, method, thisUrl, data, headers);

--- a/src/mockapi/test/unit/providers.js
+++ b/src/mockapi/test/unit/providers.js
@@ -4,131 +4,137 @@ var
   helper = require('../../../common/test-helper'),
   expect = helper.expect,
   spy = helper.spy,
-  stub = helper.stub,
-  providers = require('../../providers'),
-  MockRest = providers.MockRest,
-  Dispatcher = providers.Dispatcher;
+  stub = helper.stub;
 
-describe('MockRest Provider Basics', function () {
+describe('mockapi MockRest', function () {
 
-  var mr;
+  var
+    providers = require('../../providers'),
+    MockRest = providers.MockRest,
+    Dispatcher = providers.Dispatcher;
 
-  beforeEach(function () {
-    mr = new MockRest();
+  describe('Provider Basics', function () {
+
+    var mr;
+
+    beforeEach(function () {
+      mr = new MockRest();
+    });
+
+    it('should have basic api', function () {
+      expect(mr.mocks).to.be.empty();
+      expect(mr.mocks).to.be.a('array');
+      expect(mr.$get).to.exist();
+      expect(mr.addMocks).to.exist();
+      expect(mr.exceptions.HTTPNotFound).to.exist();
+    });
+
+    it('should have a $get instantiator for Angular', function () {
+      expect(mr.$get().registerMocks).to.be.a('function');
+    });
+
+    it('should have add mocks', function () {
+      mr.addMocks([{id: 1}]);
+      expect(mr.mocks[0].id).to.equal(1);
+    });
+
   });
 
-  it('should have basic api', function () {
-    expect(mr.mocks).to.be.empty();
-    expect(mr.mocks).to.be.a('array');
-    expect(mr.$get).to.exist();
-    expect(mr.addMocks).to.exist();
-    expect(mr.exceptions.HTTPNotFound).to.exist();
-  });
+  describe('Dispatcher', function () {
 
-  it('should have a $get instantiator for Angular', function () {
-    expect(mr.$get().registerMocks).to.be.a('function');
-  });
+    var method, data, headers, result, mock, thisUrl, responseCode, responseBody;
 
-  it('should have add mocks', function () {
-    mr.addMocks([{id: 1}]);
-    expect(mr.mocks[0].id).to.equal(1);
-  });
+    beforeEach(function () {
+      method = 'GET';
+      mock = {pattern: 'pattern'};
+      thisUrl = '/foo?arg1=val1';
+    });
 
-});
+    it('should return data and 200 for simplified mock', function () {
+      mock = {responseData: [1, 2, 3]};
+      result = Dispatcher(mock);
+      responseCode = result[0];
+      responseBody = result[1];
+      expect(responseCode).to.equal(200);
+      expect(responseBody[0]).to.equal(1);
+    });
 
-describe('MockRest Dispatcher', function () {
+    it('should return 401 when mock wants authorization not present', function () {
+      headers = {};
+      mock = {responseData: [1, 2, 3], authenticate: true};
+      result = Dispatcher(mock, method, thisUrl, data, headers);
+      responseCode = result[0];
+      responseBody = result[1];
+      expect(responseCode).to.equal(401);
+      expect(responseBody.message).to.equal('Login required')
+    });
 
-  var method, data, headers, result, mock, thisUrl, responseCode, responseBody;
+    it('should return 200 when mock wants authorization and present', function () {
+      headers = {Authorization: 'xxx'};
+      mock = {responseData: [1, 2, 3], authenticate: true};
+      result = Dispatcher(mock, method, thisUrl, data, headers);
+      responseCode = result[0];
+      responseBody = result[1];
+      expect(responseCode).to.equal(200);
+      expect(responseBody[0]).to.equal(1);
+    });
 
-  beforeEach(function () {
-    method = 'GET';
-    mock = {pattern: 'pattern'};
-    thisUrl = '/foo?arg1=val1';
-  });
+    it('should call a responder with complete request data', function () {
+      data = '{"flag": 9}';
+      var responder = function (request) {
+        return request;
+      };
+      mock = {responder: responder};
+      result = Dispatcher(mock, method, thisUrl, data, headers);
+      responseCode = result[0];
+      responseBody = result[1];
+      expect(result[0]).to.equal(200);
+      expect(responseBody.url).to.equal(thisUrl);
+      expect(responseBody.headers.Authorization).to.equal('xxx');
+      expect(responseBody.data).to.equal(data);
+      expect(responseBody.method).to.equal('GET');
+      expect(responseBody.json_body.flag).to.equal(9);
+    });
 
-  it('should return data and 200 for simplified mock', function () {
-    mock = {responseData: [1, 2, 3]};
-    result = Dispatcher(mock);
-    responseCode = result[0];
-    responseBody = result[1];
-    expect(responseCode).to.equal(200);
-    expect(responseBody[0]).to.equal(1);
-  });
+    it('should handle a raised HTTPNotFound', function () {
+      var HTTPNotFound = providers.HTTPNotFound;
+      var responder = function () {
+        throw new HTTPNotFound('some message');
+      };
+      mock = {responder: responder};
+      result = Dispatcher(mock, method, thisUrl, data, headers);
+      responseCode = result[0];
+      responseBody = result[1];
+      expect(responseCode).to.equal(404);
+      expect(responseBody.message).to.equal('some message');
+    });
 
-  it('should return 401 when mock wants authorization not present', function () {
-    headers = {};
-    mock = {responseData: [1, 2, 3], authenticate: true};
-    result = Dispatcher(mock, method, thisUrl, data, headers);
-    responseCode = result[0];
-    responseBody = result[1];
-    expect(responseCode).to.equal(401);
-    expect(responseBody.message).to.equal('Login required')
-  });
+    it('should handle a raised unauthorized', function () {
+      var HTTPUnauthorized = providers.HTTPUnauthorized;
+      var responder = function () {
+        throw new HTTPUnauthorized('some message');
+      };
+      mock = {responder: responder};
+      result = Dispatcher(mock, method, thisUrl, data, headers);
+      responseCode = result[0];
+      responseBody = result[1];
+      expect(responseCode).to.equal(401);
+      expect(responseBody.message).to.equal('some message');
+    });
 
-  it('should return 200 when mock wants authorization and present', function () {
-    headers = {Authorization: 'xxx'};
-    mock = {responseData: [1, 2, 3], authenticate: true};
-    result = Dispatcher(mock, method, thisUrl, data, headers);
-    responseCode = result[0];
-    responseBody = result[1];
-    expect(responseCode).to.equal(200);
-    expect(responseBody[0]).to.equal(1);
-  });
+    it('should handle a raised no content', function () {
+      var HTTPNoContent = providers.HTTPNoContent;
+      var responder = function () {
+        throw new HTTPNoContent();
+      };
+      mock = {responder: responder};
+      result = Dispatcher(mock, method, thisUrl, data, headers);
+      responseCode = result[0];
+      responseBody = result[1];
+      expect(responseCode).to.equal(204);
+      expect(responseBody).to.be.null();
+    });
 
-  it('should call a responder with complete request data', function () {
-    data = '{"flag": 9}';
-    var responder = function (request) {
-      return request;
-    };
-    mock = {responder: responder};
-    result = Dispatcher(mock, method, thisUrl, data, headers);
-    responseCode = result[0];
-    responseBody = result[1];
-    expect(result[0]).to.equal(200);
-    expect(responseBody.url).to.equal(thisUrl);
-    expect(responseBody.headers.Authorization).to.equal('xxx');
-    expect(responseBody.data).to.equal(data);
-    expect(responseBody.method).to.equal('GET');
-    expect(responseBody.json_body.flag).to.equal(9);
-  });
-
-  it('should handle a raised HTTPNotFound', function () {
-    var HTTPNotFound = providers.HTTPNotFound;
-    var responder = function () {
-      throw new HTTPNotFound('some message');
-    };
-    mock = {responder: responder};
-    result = Dispatcher(mock, method, thisUrl, data, headers);
-    responseCode = result[0];
-    responseBody = result[1];
-    expect(responseCode).to.equal(404);
-    expect(responseBody.message).to.equal('some message');
-  });
-
-  it('should handle a raised unauthorized', function () {
-    var HTTPUnauthorized = providers.HTTPUnauthorized;
-    var responder = function () {
-      throw new HTTPUnauthorized('some message');
-    };
-    mock = {responder: responder};
-    result = Dispatcher(mock, method, thisUrl, data, headers);
-    responseCode = result[0];
-    responseBody = result[1];
-    expect(responseCode).to.equal(401);
-    expect(responseBody.message).to.equal('some message');
-  });
-
-  it('should handle a raised no content', function () {
-    var HTTPNoContent = providers.HTTPNoContent;
-    var responder = function () {
-      throw new HTTPNoContent();
-    };
-    mock = {responder: responder};
-    result = Dispatcher(mock, method, thisUrl, data, headers);
-    responseCode = result[0];
-    responseBody = result[1];
-    expect(responseCode).to.equal(204);
-    expect(responseBody).to.be.null();
   });
 
 });

--- a/src/resourcetypes/controllers.js
+++ b/src/resourcetypes/controllers.js
@@ -5,8 +5,17 @@ function ManageController() {
 }
 
 function ListController($stateParams, items) {
+  var _this = this;
   this.resourcetype = $stateParams.resourcetype;
   this.items = items;
+
+  this.deleteResource = function (resourceId) {
+    var resource = _(items).find({id: resourceId});
+    resource.remove()
+      .then(function () {
+              _(_this.items).remove({id: resourceId});
+            });
+  }
 }
 
 function EditController(item) {

--- a/src/resourcetypes/services.js
+++ b/src/resourcetypes/services.js
@@ -9,7 +9,7 @@ function RTypesService(MdNav) {
   this.urlPrefix = 'api/resourcetypes';
 
   // Initialize the navmenu
-  var menu = MdNav.addMenu('resourcetypes', 'Resource Types');
+  var menu = MdNav.addMenu('resourcetypes', 'Resource Types', 2);
   menu.addMenuItem({
                      id: 'manage',
                      label: 'Manage',

--- a/src/resourcetypes/templates/edit.html
+++ b/src/resourcetypes/templates/edit.html
@@ -1,6 +1,8 @@
-<div>
-  <h1>Edit {{ctrl.item.title}}</h1>
-  <md-form md-model="ctrl.item"
-           md-schema="{{ctrl.schemaId}}"
-           md-form="{{ctrl.formId}}"></md-form>
+<div class="row">
+  <div class="col-md-8">
+    <h1>Edit {{ctrl.item.title}}</h1>
+    <md-form md-model="ctrl.item"
+             md-schema="{{ctrl.schemaId}}"
+             md-form="{{ctrl.formId}}"></md-form>
+  </div>
 </div>

--- a/src/resourcetypes/templates/list.html
+++ b/src/resourcetypes/templates/list.html
@@ -10,13 +10,19 @@
     </thead>
     <tbody>
     <tr ng-repeat="item in ctrl.items">
-      <td ng-bind="item.id">id</td>
-      <td ng-bind="item.title">title</td>
+      <td ng-bind="item.id" width="20%">id</td>
+      <td ng-bind="item.title" width="60%">title</td>
       <td>
         <a class="btn btn-default btn-xs"
-            ui-sref="resourcetypes.item.edit({resourcetype: ctrl.resourcetype, id: item.id})">
+           title="Edit"
+           ui-sref="resourcetypes.item.edit({resourcetype: ctrl.resourcetype, id: item.id})">
           <i class="glyphicon glyphicon-pencil"></i>
         </a>
+        <button class="btn btn-default btn-xs"
+                title="Delete"
+                ng-click="ctrl.deleteResource(item.id)">
+          <i class="glyphicon glyphicon-trash"></i>
+        </button>
       </td>
     </tr>
     </tbody>


### PR DESCRIPTION
Standard base class for mocks that eliminates need for writing mock registrations for standard operations (READ, LIST, UPDATE, REPLACE, DELETE)